### PR TITLE
Fix form fill for city and email select

### DIFF
--- a/services/aiAnswerService.js
+++ b/services/aiAnswerService.js
@@ -5,11 +5,14 @@ async function getAnswer(question) {
   const normalized = question.trim().toLowerCase();
 
   // Handle known form labels with static responses
-  if (normalized === 'First name') return 'Abhiram';
-  if (normalized === 'Last name') return 'Shaji';
-  if (normalized.includes('Phone country code')) return 'Canada (+1)';
-  if (normalized === 'Mobile phone number') return '2362553669';
-  if (normalized.includes('Email address')) return 'write4abhiram@gmail.com';
+  if (normalized === 'first name') return 'Abhiram';
+  if (normalized === 'last name') return 'Shaji';
+  if (normalized.includes('phone country code')) return 'Canada (+1)';
+  if (normalized.includes('mobile phone number')) return '2362553669';
+  if (normalized.includes('email')) return 'write4abhiram@gmail.com';
+  if (normalized.includes('city')) return 'Victoria';
+  if (normalized.includes('postal')) return 'V8N 4A8';
+  if (normalized.includes('address')) return '3904 Haro Rd';
 
   // Fall back to OpenAI for other prompts
   const rawPrompt = fs.readFileSync('prompt.txt', 'utf-8');

--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -49,8 +49,21 @@ async function handleSelect(select) {
   console.log(`📝 Select label: "${label}"`);
   const answer = await getAnswer(label);
   console.log(`🔽 Trying to select option: "${answer}"`);
-  await select.selectOption({ label: answer });
-  console.log(`✅ Selected option for "${label}"`);
+  try {
+    await select.selectOption({ label: answer });
+    console.log(`✅ Selected option for "${label}"`);
+  } catch (err) {
+    console.log(`⚠️ Option by label failed: ${err.message}. Falling back...`);
+    const options = await select.$$('option');
+    for (const opt of options) {
+      const value = await opt.getAttribute('value');
+      if (value && value.toLowerCase() !== 'select an option') {
+        await select.selectOption(value);
+        console.log(`✅ Fallback selected value "${value}" for "${label}"`);
+        break;
+      }
+    }
+  }
 }
 
 async function handleCheckbox(checkbox) {

--- a/utils/labelUtils.js
+++ b/utils/labelUtils.js
@@ -1,7 +1,17 @@
 async function getLabelFromInput(input) {
   return await input.evaluate(el => {
-    const label = el.closest('div')?.querySelector('label');
-    return label ? label.innerText : 'No label';
+    const labelEl = el.closest('div')?.querySelector('label');
+    if (labelEl) return labelEl.innerText.trim();
+    const ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel.trim();
+    const ariaLabelledBy = el.getAttribute('aria-labelledby');
+    if (ariaLabelledBy) {
+      const ref = document.getElementById(ariaLabelledBy);
+      if (ref) return ref.innerText.trim();
+    }
+    const placeholder = el.getAttribute('placeholder');
+    if (placeholder) return placeholder.trim();
+    return 'No label';
   });
 }
 


### PR DESCRIPTION
## Summary
- improve label detection with aria attributes
- add preset answers for city, postal code, and address fields
- add fallback selection logic for selects

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548be41bc0832ba9ccbb368d403ab4