### PR TITLE
Fix typeahead city field in automation

### DIFF
--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -12,11 +12,16 @@ async function handleInput(input) {
   console.log(`📝 Input label: "${label}"`);
   const answer = await getAnswer(label);
   console.log(`🔤 Filling input with: "${answer}"`);
-  await input.fill(answer);
-
   const ariaAuto = await input.getAttribute('aria-autocomplete');
   const role = await input.getAttribute('role');
-  if (ariaAuto === 'list' || role === 'combobox') {
+  const isTypeahead = ariaAuto === 'list' || role === 'combobox';
+  if (isTypeahead) {
+    await input.click({ clickCount: 3 });
+    await input.type(answer, { delay: 100 });
+  } else {
+    await input.fill(answer);
+  }
+  if (isTypeahead) {
     const page = await input.page();
     console.log('⌛ Waiting for autocomplete options...');
     try {


### PR DESCRIPTION
## Summary
- type values into autocomplete inputs instead of calling `fill`
- click first suggestion when results appear

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548dd586cc832ba9f837b93480e693