### PR TITLE
Improve LinkedIn checkbox handling

### DIFF
--- a/utils/labelUtils.js
+++ b/utils/labelUtils.js
@@ -1,7 +1,14 @@
 async function getLabelFromInput(input) {
   return await input.evaluate(el => {
+    // 1. Directly associated label via id/for
+    if (el.id) {
+      const byFor = document.querySelector(`label[for="${el.id}"]`);
+      if (byFor) return byFor.innerText.trim();
+    }
+
     const labelEl = el.closest('div')?.querySelector('label');
     if (labelEl) return labelEl.innerText.trim();
+
     const ariaLabel = el.getAttribute('aria-label');
     if (ariaLabel) return ariaLabel.trim();
     const ariaLabelledBy = el.getAttribute('aria-labelledby');


### PR DESCRIPTION
## Summary
- click labels when selecting checkboxes/radios so LinkedIn scripts run
- read label text via `for` attributes when present

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68548fa96e98832ba4ab6ba7f6ce274c