### PR TITLE
Add AI-backed label extraction

### DIFF
--- a/utils/aiLabelService.js
+++ b/utils/aiLabelService.js
@@ -1,0 +1,20 @@
+const openai = require('../config/openaiConfig');
+
+async function getAIExtractedLabel(htmlSnippet) {
+  const prompt = `
+Given the following HTML snippet from a form, extract the **question being asked** to the user. Your output should be **only the question** in plain text.
+
+HTML:
+${htmlSnippet}
+  `.trim();
+
+  const response = await openai.chat.completions.create({
+    model: 'gpt-4',
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: 50,
+  });
+
+  return response.choices[0].message.content.trim();
+}
+
+module.exports = { getAIExtractedLabel };


### PR DESCRIPTION
## Summary
- add `aiLabelService` for GPT-based label extraction
- use AI fallback in `getLabelFromInput`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68549854c924832b9d07ac981bcf9f69