### PR TITLE
Improve radio question handling

### DIFF
--- a/services/formFillService.js
+++ b/services/formFillService.js
@@ -9,11 +9,11 @@ const { delay } = require('../utils/delay');
 require('dotenv').config();
 const DELAY_MS = parseInt(process.env.DELAY_MS || '1000', 10);
 
-async function processElements(elements, handler, label) {
+async function processElements(elements, handler, label, page) {
   console.log(`🔍 Found ${elements.length} ${label}`);
   for (const element of elements) {
     try {
-      await handler(element);
+      await handler(element, page);
       await delay(DELAY_MS);
     } catch (err) {
       console.warn(`❌ Error processing ${label.slice(0, -1)}: ${err.message}`);
@@ -42,15 +42,15 @@ async function fillForm(page) {
     )
   );
 
-  await processElements(inputs, handleInput, 'inputs');
+  await processElements(inputs, handleInput, 'inputs', page);
   await delay(DELAY_MS);
-  await processElements(textareas, handleTextarea, 'textareas');
+  await processElements(textareas, handleTextarea, 'textareas', page);
   await delay(DELAY_MS);
-  await processElements(selects, handleSelect, 'selects');
+  await processElements(selects, handleSelect, 'selects', page);
   await delay(DELAY_MS);
-  await processElements(checkboxes, handleCheckbox, 'checkboxes');
+  await processElements(checkboxes, handleCheckbox, 'checkboxes', page);
   await delay(DELAY_MS);
-  await processElements(radios, handleRadio, 'radios');
+  await processElements(radios, handleRadio, 'radios', page);
 }
 
 module.exports = { fillForm };

--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -129,7 +129,7 @@ async function handleCheckbox(checkbox) {
   }
 }
 
-async function handleRadio(radio) {
+async function handleRadio(radio, page) {
   const checked = await radio.isChecked();
   if (checked) return;
 
@@ -141,7 +141,6 @@ async function handleRadio(radio) {
   const name = await radio.getAttribute('name');
   if (!name) return;
 
-  const page = radio._page || (await radio.page());
   const radiosInGroup = await page.$$(`input[type="radio"][name="${name}"]`);
 
   const normalizedAnswer = answer.trim().toLowerCase();

--- a/utils/labelUtils.js
+++ b/utils/labelUtils.js
@@ -2,6 +2,13 @@ const { getAIExtractedLabel } = require('./aiLabelService');
 
 async function getLabelFromInput(input) {
   const label = await input.evaluate(el => {
+    // For radio buttons, prefer the fieldset legend text which usually
+    // represents the actual question for the group
+    if (el.getAttribute('type') === 'radio') {
+      const legend = el.closest('fieldset')?.querySelector('legend');
+      if (legend) return legend.innerText.trim();
+    }
+
     // 1. Directly associated label via id/for
     if (el.id) {
       const byFor = document.querySelector(`label[for="${el.id}"]`);


### PR DESCRIPTION
## Summary
- fetch radio group question from its fieldset legend
- pass `page` through form helpers so radios use it without `.page()` call
- remove `radio.page()` usage that caused errors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68549a4218e8832b93bca5fdf5dd3fa6