### PR TITLE
Improve radio question handling

### DIFF
--- a/utils/labelUtils.js
+++ b/utils/labelUtils.js
@@ -43,4 +43,20 @@ async function getLabelFromInput(input) {
   return aiLabel;
 }
 
-module.exports = { getLabelFromInput };
+async function getRadioOptionLabel(input) {
+  return input.evaluate(el => {
+    if (el.id) {
+      const byFor = document.querySelector(`label[for="${el.id}"]`);
+      if (byFor) return byFor.innerText.trim();
+    }
+    const parentLabel = el.closest('label');
+    if (parentLabel) return parentLabel.innerText.trim();
+
+    const ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel.trim();
+
+    return el.getAttribute('value') || '';
+  });
+}
+
+module.exports = { getLabelFromInput, getRadioOptionLabel };

--- a/utils/numberUtils.js
+++ b/utils/numberUtils.js
@@ -1,0 +1,39 @@
+function extractNumericValue(str) {
+  if (!str) return NaN;
+  const num = str.match(/\d+(?:\.\d+)?/);
+  if (num) return parseFloat(num[0]);
+
+  const words = {
+    zero: 0,
+    one: 1,
+    two: 2,
+    three: 3,
+    four: 4,
+    five: 5,
+    six: 6,
+    seven: 7,
+    eight: 8,
+    nine: 9,
+    ten: 10,
+    eleven: 11,
+    twelve: 12,
+    thirteen: 13,
+    fourteen: 14,
+    fifteen: 15,
+    sixteen: 16,
+    seventeen: 17,
+    eighteen: 18,
+    nineteen: 19,
+    twenty: 20,
+  };
+
+  for (const token of str.toLowerCase().split(/\s|-/)) {
+    if (words[token] !== undefined) {
+      return words[token];
+    }
+  }
+
+  return NaN;
+}
+
+module.exports = { extractNumericValue };


### PR DESCRIPTION
## Summary
- add numeric parsing helper
- capture labels for radio options
- refine radio button selection logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68549c82fd18832b991137d128aaa67e