### PR TITLE
Fix cover letter automation

### DIFF
--- a/services/aiAnswerService.js
+++ b/services/aiAnswerService.js
@@ -13,6 +13,8 @@ async function getAnswer(question) {
   if (normalized.includes('city')) return 'Victoria, British Columbia, Canada';
   if (normalized.includes('postal')) return 'V8N 4A8';
   if (normalized.includes('address')) return '3904 Haro Rd';
+  if (normalized.includes('cover letter'))
+    return fs.readFileSync('coverletter.txt', 'utf-8');
 
   // Fall back to OpenAI for other prompts
   const rawPrompt = fs.readFileSync('prompt.txt', 'utf-8');


### PR DESCRIPTION
## Summary
- return contents of `coverletter.txt` whenever a `Cover Letter` field is requested

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: cannot find module 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68549e88214c832b9ad4c7b7fd4523d3