### PR TITLE
Fix radio handler page usage

### DIFF
--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -149,9 +149,9 @@ async function handleRadio(radio, page) {
     return;
   }
 
-  const pageForRadio = await radio.page();
-  await pageForRadio.waitForTimeout(500);
-  const radiosInGroup = await pageForRadio.$$(`input[type="radio"][name="${name}"]`);
+  // `page` is already passed in from the caller so use it directly
+  await page.waitForTimeout(500);
+  const radiosInGroup = await page.$$(`input[type="radio"][name="${name}"]`);
 
   const normalizedAnswer = answer.trim().toLowerCase();
   const numericAnswer = extractNumericValue(normalizedAnswer);


### PR DESCRIPTION
## Summary
- remove `radio.page()` call in `handleRadio`
- use the passed `page` object directly when querying radio options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854a40ebd00832ba2d73429f6387290