### PR TITLE
Fix detached radio elements

### DIFF
--- a/services/formFillService.js
+++ b/services/formFillService.js
@@ -13,6 +13,15 @@ async function processElements(elements, handler, label, page) {
   console.log(`🔍 Found ${elements.length} ${label}`);
   for (const element of elements) {
     try {
+      // Skip detached elements which may result from dynamic form updates
+      const attached = await element
+        .evaluate(el => el.isConnected)
+        .catch(() => false);
+      if (!attached) {
+        console.log(`⚠️ Skipping detached ${label.slice(0, -1)}.`);
+        continue;
+      }
+
       await handler(element, page);
       await delay(DELAY_MS);
     } catch (err) {

--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -134,6 +134,15 @@ async function handleCheckbox(checkbox) {
 }
 
 async function handleRadio(radio, page) {
+  // Ensure element is still in the DOM before interacting
+  const attached = await radio
+    .evaluate(el => el.isConnected)
+    .catch(() => false);
+  if (!attached) {
+    console.log('⚠️ Radio element detached. Skipping.');
+    return;
+  }
+
   const checked = await radio.isChecked();
   if (checked) return;
 


### PR DESCRIPTION
## Summary
- handle detached elements in form processing
- skip detached radios before accessing them

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8d2a024832b81b596fe7b221583