### PR TITLE
Fix Easy Apply loops and support Continue applying

### DIFF
--- a/services/autoApplyService.js
+++ b/services/autoApplyService.js
@@ -81,11 +81,14 @@ async function autoApply(jobsUrl) {
 
       const doneBtn = await page.$('button:has-text("Done")');
       const submit = await page.$('button:has-text("Submit application")');
+      const continueApplying = await page.$(
+        'button:has-text("Continue applying"), button:has-text("Continue to apply")'
+      );
       const continueAnyway = await page.$('button:has-text("Continue anyway")');
+      const easyApplyAgain = await page.$('button.jobs-apply-button');
       const next = await page.$(
         'button:has-text("Next"), button:has-text("Review"), button:has-text("Submit")'
       );
-      const easyApplyAgain = await page.$('button.jobs-apply-button');
 
       if (doneBtn) {
         console.log('✅ Done button detected. Finishing application...');
@@ -101,11 +104,19 @@ async function autoApply(jobsUrl) {
         logJob('applied', await job.innerText(), await page.url());
         console.log('✅ Application submitted and logged.');
         await delay(DELAY_MS);
+      } else if (continueApplying) {
+        console.log('➡️ Clicking Continue applying...');
+        await continueApplying.click();
+        await page.waitForTimeout(1000);
+        await delay(DELAY_MS);
       } else if (continueAnyway) {
         console.log('➡️ Clicking Continue anyway...');
         await continueAnyway.click();
         await page.waitForTimeout(1000);
         await delay(DELAY_MS);
+      } else if (easyApplyAgain) {
+        console.log('🔄 Detected Easy Apply button. Restarting application loop...');
+        hasNext = false;
       } else if (next) {
         console.log('➡️ Clicking Next...');
         try {
@@ -117,9 +128,6 @@ async function autoApply(jobsUrl) {
           await handleStuckForm(page, job);
           hasNext = false;
         }
-      } else if (easyApplyAgain) {
-        console.log('🔄 Detected Easy Apply button. Restarting application loop...');
-        hasNext = false;
       } else {
         console.log('⚠️ No Next, Submit, or Done button. Exiting form.');
         await handleStuckForm(page, job);


### PR DESCRIPTION
## Summary
- support `Continue applying` buttons
- prioritize detecting `Easy Apply` after page refresh to avoid stuck loops

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854d49b9944832bbbc9044631fb7517