### PR TITLE
Fix done button wait

### DIFF
--- a/services/autoApplyService.js
+++ b/services/autoApplyService.js
@@ -115,7 +115,8 @@ async function autoApply(jobsUrl) {
 
       const doneBtn = await waitForVisibleButton(
         page,
-        'button:has-text("Done"), button[aria-label="Done"]'
+        'button:has-text("Done"), button[aria-label="Done"]',
+        10000
       );
       const submit = await waitForVisibleButton(
         page,


### PR DESCRIPTION
## Summary
- extend waiting time for the "Done" button in `autoApplyService`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854e130faac832bbbeb0de659efab18