### PR TITLE
Fix checkbox handling for forms

### DIFF
--- a/services/formFillService.js
+++ b/services/formFillService.js
@@ -42,7 +42,7 @@ async function fillForm(page) {
   const textareas = await filterVisible(await page.$$('form textarea'));
   const selects = await filterVisible(await page.$$('form select'));
   const checkboxes = await filterVisible(
-    await page.$$('input[type="checkbox"]')
+    await page.$$('form input[type="checkbox"]')
   );
   const radios = await filterVisible(await page.$$('form input[type="radio"]'));
   const inputs = await filterVisible(


### PR DESCRIPTION
## Summary
- restrict checkbox detection to checkboxes inside forms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854f31e0020832bb224c278df58c460