### PR TITLE
Close lazy dropdown after location entry

### DIFF
--- a/services/formHandlers.js
+++ b/services/formHandlers.js
@@ -66,6 +66,13 @@ async function handleInput(input, page) {
     } catch {
       console.log(`⚠️ Autocomplete options not found for "${label}"`);
     }
+
+    try {
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(500);
+    } catch (err) {
+      console.log(`⚠️ Failed to close dropdown for "${label}": ${err.message}`);
+    }
   }
 
   console.log(`✅ Filled input for "${label}"`);


### PR DESCRIPTION
## Summary
- ensure that typeahead fields close properly after selecting the autocomplete option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854f53f7174832b9744043337380c7e