### PR TITLE
refactor: split autoApply helpers

### DIFF
--- a/services/autoApply/clickAnyContinueButton.js
+++ b/services/autoApply/clickAnyContinueButton.js
@@ -1,0 +1,24 @@
+const { delay } = require('../../utils/delay');
+
+async function clickAnyContinueButton(page, delayMs) {
+  const buttons = await page.$$('button');
+  for (const btn of buttons) {
+    const aria = (await btn.getAttribute('aria-label')) || '';
+    const text = (await btn.innerText()) || '';
+    if (
+      aria.toLowerCase().includes('continue the apply process') ||
+      text.toLowerCase().includes('continue applying') ||
+      text.toLowerCase().includes('continue to apply') ||
+      text.toLowerCase().includes('continue anyway')
+    ) {
+      console.log(`➡️ Clicking continue button: ${aria || text}`);
+      await btn.click();
+      await page.waitForTimeout(1000);
+      await delay(delayMs);
+      return true;
+    }
+  }
+  return false;
+}
+
+module.exports = { clickAnyContinueButton };

--- a/services/autoApply/handleStuckForm.js
+++ b/services/autoApply/handleStuckForm.js
@@ -1,0 +1,36 @@
+const { logJob } = require('../../utils/logger');
+const { delay } = require('../../utils/delay');
+
+async function handleStuckForm(page, job, delayMs) {
+  console.log('❌ Handling stuck form...');
+  const closeBtn =
+    (await page.$('button[aria-label="Dismiss"], button[aria-label="Close"]')) ||
+    (await page.$('button[aria-label="Discard"], button[aria-label="Cancel"]'));
+  if (closeBtn) {
+    await closeBtn.click();
+    await page.waitForTimeout(1000);
+    const discard = await page.$('button:has-text("Discard")');
+    if (discard) {
+      await discard.click();
+      await page.waitForTimeout(1000);
+    }
+  }
+
+  const saveJob = await page.$('button.jobs-save-button, button:has-text("Save")');
+  if (saveJob) {
+    await saveJob.click();
+    console.log('💾 Job saved for later.');
+  }
+
+  const dismissJob = await job.$('button[aria-label^="Dismiss"]');
+  if (dismissJob) {
+    await dismissJob.click();
+    console.log('🗑️ Job dismissed after failure.');
+  }
+
+  logJob('skipped', await job.innerText(), await page.url());
+  await page.waitForTimeout(1000);
+  await delay(delayMs);
+}
+
+module.exports = { handleStuckForm };

--- a/services/autoApply/waitForVisibleButton.js
+++ b/services/autoApply/waitForVisibleButton.js
@@ -1,0 +1,14 @@
+async function waitForVisibleButton(page, selector, timeout = 2000) {
+  try {
+    await page.waitForSelector(selector, { timeout });
+    const btn = await page.$(selector);
+    if (btn && (await btn.isVisible())) {
+      return btn;
+    }
+  } catch (err) {
+    // ignore timeout errors
+  }
+  return null;
+}
+
+module.exports = { waitForVisibleButton };


### PR DESCRIPTION
## Summary
- extract auto-apply helper functions into separate modules
- update autoApplyService to use new helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689705760edc832b8272fbbf2cbbc2d1